### PR TITLE
fix: dont delete agent, feature: enable anti-aliasing

### DIFF
--- a/src/PixiApp.tsx
+++ b/src/PixiApp.tsx
@@ -225,6 +225,7 @@ const PixiApp = forwardRef(({
                     height: height, 
                     canvas: canvas, 
                     background: BACKGROUND_COLOR,
+                    antialias: true,  // for smooooooth circles
                 }).then(() => {
                     setApp(pixiApp);
                 });

--- a/src/PixiApp.tsx
+++ b/src/PixiApp.tsx
@@ -202,8 +202,6 @@ const PixiApp = forwardRef(({
             if (currentTimestep >= solution.length - 1) {
                 if (loopAnimationRef.current) {
                     resetTimestep();
-                } else {
-                    viewport.removeChild(agents);
                 }
                 return;
             }


### PR DESCRIPTION
Currently, if you have looping disabled and the animation reaches the end of the solution, the agents are deleted and you can't restart the animation without completely reloading the solution file. Now, the agents are retained and you can manipulate the animation as you would expect.

Also, this enables anti-aliasing :)