### PR TITLE
enhancement: blur file input after use

### DIFF
--- a/src/GraphLoader.tsx
+++ b/src/GraphLoader.tsx
@@ -16,6 +16,10 @@ function GraphLoader({ onGraphChange }: GraphLoaderProps) {
             newValue.text().then((text) => {
                 const g = new Graph(text);
                 onGraphChange(g);
+                // Blur (remove focus from) the file input
+                if (document.activeElement instanceof HTMLElement) {
+                    document.activeElement.blur();
+                }
             });
         }
 

--- a/src/SolutionLoader.tsx
+++ b/src/SolutionLoader.tsx
@@ -15,6 +15,10 @@ function SolutionLoader({ onSolutionChange }: SolutionLoaderProps) {
         if (newValue) {
             newValue.text().then((text) => {
                 onSolutionChange(parseSolution(text));
+                // Blur (remove focus from) the file input
+                if (document.activeElement instanceof HTMLElement) {
+                    document.activeElement.blur();
+                }
             });
         }
     }


### PR DESCRIPTION
Currently if you select a solution, the animation will begin, but the document focus will still be on the file input. If you then try to use spacebar to pause the animation, it will open the file selection dialog. This change blurs (removes the focus from) the map and solution file input elements after use.