### PR TITLE
bugfix: step forward and backward with stepSize() instead of speed

### DIFF
--- a/src/PixiApp.tsx
+++ b/src/PixiApp.tsx
@@ -89,11 +89,11 @@ const PixiApp = forwardRef(({
 
     useImperativeHandle(ref, () => ({
         skipBackward: () => {
-            timestepRef.current = Math.max(0, timestepRef.current - speedRef.current);
+            timestepRef.current = Math.max(0, timestepRef.current - stepSize());
         },
         skipForward: () => {
             if (solution) {
-                timestepRef.current = Math.min(timestepRef.current + speedRef.current, solution.length - 1);
+                timestepRef.current = Math.min(timestepRef.current + stepSize(), solution.length - 1);
             }
         },
         restart: () => {


### PR DESCRIPTION
the handlers for stepping forward and backward were mistakenly using the speed value rather than the stepsize