### PR TITLE
bugfix: animation control caused animation restart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ function App() {
             loopAnimation={loopAnimation}
             showAgentId={showAgentId}
             tracePaths={tracePaths}
-            setCanScreenshot={(canScreenshot: boolean) => setCanScreenshot(canScreenshot)}
+            setCanScreenshot={setCanScreenshot}
           />
         </Grid>
         <Grid size={4}>


### PR DESCRIPTION
defining this function inline caused a redefinition every time `App`'s state changed