### PR TITLE
fix: round stepSize to one decimal place

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapf-visualizer",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/AnimationControl.tsx
+++ b/src/AnimationControl.tsx
@@ -93,12 +93,14 @@ function AnimationControl({
     setShowGoals,
     showGoalVectors,
     setShowGoalVectors,
-}: AnimationControlProps) {  
+}: AnimationControlProps) { 
+    const roundAndSetStepSize = (value: number) => {
+        onStepSizeChange(Number(value.toFixed(1)));
+    }
+    
     const handleSliderChange = (event: Event, value: number | number[]) => {
         event.preventDefault();
-        if (typeof value === 'number') {
-            onStepSizeChange(value);
-        }
+        if (typeof value === 'number') roundAndSetStepSize(value);
     };
 
     useEffect(() => {
@@ -122,9 +124,9 @@ function AnimationControl({
             } else if (event.key === SHOW_AGENT_ID_KEY) {
                 onShowAgentIdChange(!showAgentId);
             } else if (event.key === STEP_SIZE_UP_KEY && stepSize + STEP_SIZE_INCREMENT <= STEP_SIZE_MAX) {
-                onStepSizeChange(stepSize + STEP_SIZE_INCREMENT);
+                roundAndSetStepSize(stepSize + STEP_SIZE_INCREMENT);
             } else if (event.key === STEP_SIZE_DOWN_KEY && stepSize - STEP_SIZE_INCREMENT >= STEP_SIZE_MIN) {
-                onStepSizeChange(stepSize - STEP_SIZE_INCREMENT);
+                roundAndSetStepSize(stepSize - STEP_SIZE_INCREMENT);
             } else if (event.key === TRACE_PATHS_KEY) {
                 onTracePathsChange(!tracePaths);
             } else if (event.key === SCREENSHOT_KEY) {
@@ -159,7 +161,7 @@ function AnimationControl({
                     }
                 >
                     <Slider
-                        value={Number(stepSize.toFixed(1))}
+                        value={stepSize}
                         step={STEP_SIZE_INCREMENT}
                         marks
                         min={STEP_SIZE_MIN}
@@ -170,7 +172,7 @@ function AnimationControl({
                     />
                 </Tooltip>
                 <Tooltip title="Reset step size">
-                    <Button onClick={() => onStepSizeChange(1)}>
+                    <Button onClick={() => roundAndSetStepSize(1)}>
                         <RestartAltIcon />
                     </Button>
                 </Tooltip>

--- a/src/AnimationControl.tsx
+++ b/src/AnimationControl.tsx
@@ -159,7 +159,7 @@ function AnimationControl({
                     }
                 >
                     <Slider
-                        value={stepSize}
+                        value={Number(stepSize.toFixed(1))}
                         step={STEP_SIZE_INCREMENT}
                         marks
                         min={STEP_SIZE_MIN}


### PR DESCRIPTION
When using the arrow keys to adjust step size, sometimes float addition will result in a situation like this:
<img width="197" alt="image" src="https://github.com/user-attachments/assets/3137e9ec-9826-4ead-b2e7-ef0f506478b5" />

So, let's round stepSize.